### PR TITLE
Use secure URI in Vcs-Git/Vcs-Browser control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+aspell-kk (0.2-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs-Git and Vcs-Browser control headers.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 02:33:10 +0100
+
 aspell-kk (0.2-1) unstable; urgency=low
 
   * Initial release. Closes: #594040 (ITP).

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Timur Birsh <taem@linukz.org>
 Build-Depends: debhelper (>= 9), dictionaries-common-dev (>= 1.12.11), aspell (>= 0.60)
 Standards-Version: 3.9.4
 Homepage: http://sourceforge.net/projects/kazlinux/
-Vcs-Git: git://github.com/taem/aspell-kk.git
-Vcs-Browser: http://github.com/taem/aspell-kk/tree/master
+Vcs-Git: https://github.com/taem/aspell-kk.git
+Vcs-Browser: https://github.com/taem/aspell-kk/tree/master
 
 Package: aspell-kk
 Architecture: all


### PR DESCRIPTION
Use secure URI in Vcs-Git control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
